### PR TITLE
Fixed unit test as for lienzo-core 2.0.285-RELEASE upgrade.

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleListTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleListTest.java
@@ -236,7 +236,7 @@ public class WiresShapeControlHandleListTest
         tested.show();
         verify(controlHandleList).showOn(any(Group.class));
         verify(controlHandleList, never()).hide();
-        verify(controls).show();
+        verify(controls, never()).show();
         verify(controls, never()).hide();
     }
 
@@ -266,7 +266,7 @@ public class WiresShapeControlHandleListTest
 
         verify(controlHandleList).showOn(any(Group.class));
         verify(controlHandleList, never()).hide();
-        verify(controls, times(2)).show();
+        verify(controls, never()).show();
         verify(controls, never()).hide();
     }
 


### PR DESCRIPTION
Hey @manstis @hasys @SprocketNYC 

Once [this other PR](https://github.com/ahome-it/lienzo-core/pull/149) gets updated, here is the fix on the unit tests side for it. 
PS: Right now this repo build is broken, it seems due to still using an old core version. Anyway no worries. @SprocketNYC can I feel free to fix here in `lienzo-tests` the versions present on pom file? Or do you have some automated release process? 

Thanks in advance!
Roger
