### PR TITLE
20286 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ Before setup, please confirm these two pre-requisites:
  Ensure your dependency tree resolves:                         
  
         com.google.gwt.gwtmockito:gwtmockito:1.1.6
-        
-* Your project dependency version resolved for *Lienzo Core* artifact must be at least the same one used in this project. 
-You can check it [here](./pom.xml). If you use older lienzo versions, you can hit with class signature incompatibilities. 
- Ensure your dependency tree resolves:
- 
-        com.ahome-it:lienzo-core:2.0.280-RELEASE
 
 Build
 =====
@@ -279,7 +273,5 @@ Use the testing artifact version supported for a concrete Lienzo-Core release:
         Lienzo-Core            Lienzzo-Tests
         ************************************
         2.0.275-RELEASE          1.0.0-RC2
-        2.0.286-RELEASE (+)      current
-        
-NOTE: Symbol "+" indicates from the given version until latest stable release one.               
+        2.0.286-RELEASE (+)      Using same versions as `lienzo-core`
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
   <properties>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <version.com.ahomeit.lienzo>2.0.286-RELEASE</version.com.ahomeit.lienzo>
+    <version.com.ahomeit.lienzo>${project.version}</version.com.ahomeit.lienzo>
     <version.com.google.gwt>2.7.0</version.com.google.gwt>
     <version.junit>4.11</version.junit>
     <version.org.mockito>1.9.5</version.org.mockito>

--- a/src/main/java/com/ait/lienzo/test/settings/DefaultSettingsHolder.java
+++ b/src/main/java/com/ait/lienzo/test/settings/DefaultSettingsHolder.java
@@ -16,6 +16,8 @@
 
 package com.ait.lienzo.test.settings;
 
+import com.ait.lienzo.test.stub.overlays.NArrayBaseJSO;
+import com.ait.lienzo.test.stub.overlays.Point2DArrayJSO;
 import com.ait.lienzo.test.translator.*;
 
 /**
@@ -49,12 +51,16 @@ import com.ait.lienzo.test.translator.*;
                 com.ait.lienzo.test.stub.overlays.JsArrayMixed.class,
                 com.ait.lienzo.test.stub.overlays.PathPartListJSO.class,
                 com.ait.lienzo.test.stub.overlays.PathPartEntryJSO.class,
+                com.ait.lienzo.test.stub.overlays.Point2DArrayJSO.class,
+                com.ait.lienzo.test.stub.overlays.NArrayBaseJSO.class,
+                com.ait.lienzo.test.stub.overlays.NFastPrimitiveArrayBaseJSO.class,
+                com.ait.lienzo.test.stub.overlays.NFastDoubleArrayJSO.class,
                 com.ait.lienzo.test.stub.overlays.OptionalNodeFields.class,
-		 com.ait.lienzo.test.stub.overlays.OptionalShapeFields.class,
-		 com.ait.lienzo.test.stub.overlays.OptionalGroupOfFields.class,
+                com.ait.lienzo.test.stub.overlays.OptionalShapeFields.class,
+                com.ait.lienzo.test.stub.overlays.OptionalGroupOfFields.class,
                 com.ait.lienzo.test.stub.Attributes.class,
                 com.ait.lienzo.test.stub.NFastArrayList.class,
-                com.ait.lienzo.test.stub.NFastStringMap.class
+                com.ait.lienzo.test.stub.NFastStringMap.class,
         },
         
         jsoStubs = {
@@ -73,8 +79,6 @@ import com.ait.lienzo.test.translator.*;
                 "com.ait.lienzo.client.core.image.filter.ImageDataFilterCommonOps",
                 "com.ait.lienzo.client.core.image.filter.ImageDataFilter$FilterTableArray",
                 "com.ait.lienzo.client.core.image.filter.ImageDataFilter$FilterTableArray",
-                "com.ait.tooling.nativetools.client.NArrayBaseJSO",
-                "com.ait.tooling.nativetools.client.collection.NFastDoubleArrayJSO",
                 "com.ait.tooling.nativetools.client.collection.NFastBooleanArrayJSO",
                 "com.ait.tooling.nativetools.client.collection.NFastIntegerArrayJSO",
                 "com.ait.tooling.nativetools.client.collection.NFastStringArrayJSO",
@@ -86,8 +90,7 @@ import com.ait.lienzo.test.translator.*;
                 "com.ait.tooling.nativetools.client.util.Performance$PerformanceJSO",
                 "com.ait.tooling.nativetools.client.webworker.WebWorker$WebWorkerJSO",
                 "com.ait.tooling.nativetools.client.usermedia.UserMediaStream",
-                "com.ait.tooling.nativetools.client.NObjectBaseJSO",
-                "com.ait.lienzo.client.core.types.Point2DArray$Point2DArrayJSO"
+                "com.ait.tooling.nativetools.client.NObjectBaseJSO"
         },
         
         jsoMocks = {},

--- a/src/main/java/com/ait/lienzo/test/stub/Attributes.java
+++ b/src/main/java/com/ait/lienzo/test/stub/Attributes.java
@@ -985,9 +985,10 @@ public class Attributes
         }
     }
 
+    // Lienzo-mockito: Replaced use of "cast()" by just using java regular casting.
     public final Point2DArray getControlPoints()
     {
-        JsArray<JavaScriptObject> points = getArrayOfJSO(Attribute.CONTROL_POINTS.getProperty());
+        Point2DArray.Point2DArrayJSO points = (Point2DArray.Point2DArrayJSO) m_jso.getAsJSO(Attribute.CONTROL_POINTS.getProperty());
 
         if (null != points)
         {

--- a/src/main/java/com/ait/lienzo/test/stub/overlays/NArrayBaseJSO.java
+++ b/src/main/java/com/ait/lienzo/test/stub/overlays/NArrayBaseJSO.java
@@ -1,0 +1,153 @@
+package com.ait.lienzo.test.stub.overlays;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.ait.lienzo.test.annotation.StubClass;
+import com.ait.tooling.common.api.json.JSONType;
+import com.ait.tooling.nativetools.client.NJSONReplacer;
+import com.ait.tooling.nativetools.client.NUtils;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.json.client.JSONArray;
+import org.apache.commons.lang3.StringUtils;
+
+@StubClass("com.ait.tooling.nativetools.client.NArrayBaseJSO")
+public class NArrayBaseJSO<T extends NArrayBaseJSO<T>> extends JavaScriptObject {
+
+    protected final List<Object> list = new ArrayList<Object>();
+
+    protected static <T extends NArrayBaseJSO<T>> T createNArrayBaseJSO() {
+        return (T) new NArrayBaseJSO<T>();
+    }
+
+    protected NArrayBaseJSO() {
+    }
+
+    public JSONArray toJSONArray() {
+        return new JSONArray(this);
+    }
+
+    public String toJSONString() {
+        return NUtils.JSON.toJSONString(this);
+    }
+
+    public String toJSONString(final NJSONReplacer replacer) {
+        return NUtils.JSON.toJSONString(this,
+                                        replacer);
+    }
+
+    public String toJSONString(final String indent) {
+        return NUtils.JSON.toJSONString(this,
+                                        indent);
+    }
+
+    public String toJSONString(final NJSONReplacer replacer,
+                               final String indent) {
+        return NUtils.JSON.toJSONString(this,
+                                        replacer,
+                                        indent);
+    }
+
+    public String toJSONString(final int indent) {
+        return NUtils.JSON.toJSONString(this,
+                                        indent);
+    }
+
+    public String toJSONString(final NJSONReplacer replacer,
+                               final int indent) {
+        return NUtils.JSON.toJSONString(this,
+                                        replacer,
+                                        indent);
+    }
+
+    public void clear() {
+        list.clear();
+    }
+
+    public String join() {
+        return join(",");
+    }
+
+    public JSONType getNativeTypeOf(final int index) {
+        if ((index < 0) || (index >= size())) {
+            return JSONType.UNDEFINED;
+        }
+        return NUtils.Native.getNativeTypeOf(this,
+                                             index);
+    }
+
+    public boolean isNull(final int index) {
+        if ((index < 0) || (index >= size())) {
+            return true;
+        }
+        return list.get(index) == null;
+    }
+
+    public boolean isDefined(final int index) {
+        if ((index < 0) || (index >= size())) {
+            return false;
+        }
+        return list.get(index) != null;
+    }
+
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    public int size() {
+        return list.size();
+    }
+
+    public void setSize(int size) {
+
+    }
+
+    public void splice(int beg,
+                       int removed) {
+        // TODO
+    }
+
+    public void reverse() {
+        Collections.reverse(list);
+    }
+
+    public String join(String separator) {
+        return StringUtils.join(list,
+                                separator);
+    }
+
+    public T concat(T value) {
+        list.addAll(value.list);
+        return value;
+    }
+
+    public T copy() {
+        return isEmpty() ? null : (T) list.get(list.size() - 1);
+    }
+
+    public T slice(int beg) {
+        // TOD
+        return copy();
+    }
+
+    public T slice(int beg,
+                   int end) {
+        // TOD
+        return copy();
+    }
+
+    protected double doShift() {
+        double t = (double) list.get(0);
+
+        list.remove(0);
+
+        return t;
+    }
+
+    protected void doUnShift(final double value) {
+        list.add(0,
+                 value);
+    }
+}
+

--- a/src/main/java/com/ait/lienzo/test/stub/overlays/NFastDoubleArrayJSO.java
+++ b/src/main/java/com/ait/lienzo/test/stub/overlays/NFastDoubleArrayJSO.java
@@ -1,0 +1,81 @@
+package com.ait.lienzo.test.stub.overlays;
+
+import com.ait.lienzo.test.annotation.StubClass;
+
+@StubClass("com.ait.tooling.nativetools.client.collection.NFastDoubleArrayJSO")
+public class NFastDoubleArrayJSO extends NFastPrimitiveArrayBaseJSO<NFastDoubleArrayJSO> {
+
+    public static NFastDoubleArrayJSO make(final double d,
+                                           final double... list) {
+        final NFastDoubleArrayJSO jso = make();
+
+        jso.push(d,
+                 list);
+
+        return jso;
+    }
+
+    public static NFastDoubleArrayJSO make() {
+        return new NFastDoubleArrayJSO();
+    }
+
+    protected NFastDoubleArrayJSO() {
+    }
+
+    public double[] toArray() {
+        final int size = size();
+
+        final double[] array = new double[size];
+
+        for (int i = 0; i < size; i++) {
+            array[i] = get(i);
+        }
+        return array;
+    }
+
+    public void push(final double d,
+                     final double... list) {
+        push(d);
+
+        final int size = list.length;
+
+        for (int i = 0; i < size; i++) {
+            push(list[i]);
+        }
+    }
+
+    public void push(double value) {
+        list.add(value);
+    }
+
+    public void set(int indx,
+                    double value) {
+        list.set(indx,
+                 value);
+    }
+
+    public double get(int indx) {
+        return (double) list.get(indx);
+    }
+
+    public double pop() {
+        double result = 0;
+
+        if (!list.isEmpty()) {
+            int i = list.size() - 1;
+
+            result = (double) list.get(i);
+
+            list.remove(i);
+        }
+        return result;
+    }
+
+    public double shift() {
+        return doShift();
+    }
+
+    public boolean contains(double value) {
+        return list.contains(value);
+    }
+}

--- a/src/main/java/com/ait/lienzo/test/stub/overlays/NFastPrimitiveArrayBaseJSO.java
+++ b/src/main/java/com/ait/lienzo/test/stub/overlays/NFastPrimitiveArrayBaseJSO.java
@@ -1,0 +1,21 @@
+package com.ait.lienzo.test.stub.overlays;
+
+import com.ait.lienzo.test.annotation.StubClass;
+
+@StubClass("com.ait.tooling.nativetools.client.collection.NFastPrimitiveArrayBaseJSO")
+public class NFastPrimitiveArrayBaseJSO<T extends NFastPrimitiveArrayBaseJSO<T>> extends NArrayBaseJSO<T> {
+
+
+    protected NFastPrimitiveArrayBaseJSO() {
+    }
+
+    public T sort() {
+        // TODO
+        return copy();
+    }
+
+    public T uniq() {
+        // TODO
+        return copy();
+    }
+}

--- a/src/main/java/com/ait/lienzo/test/stub/overlays/Point2DArrayJSO.java
+++ b/src/main/java/com/ait/lienzo/test/stub/overlays/Point2DArrayJSO.java
@@ -1,0 +1,60 @@
+package com.ait.lienzo.test.stub.overlays;
+
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.test.annotation.StubClass;
+
+/**
+ * Stub for class <code>com.ait.lienzo.client.core.types.Point2DArray$Point2DArrayJSO</code>.
+ *
+ * @author Roger Martinez
+ * @since 1.0
+ *
+ */
+@StubClass("com.ait.lienzo.client.core.types.Point2DArray$Point2DArrayJSO")
+public class Point2DArrayJSO extends JsArray<Point2D.Point2DJSO> {
+    protected Point2DArrayJSO() {
+    }
+
+    public void pop() {
+        this.pop();
+    }
+
+    public static Point2DArrayJSO make() {
+        return new Point2DArrayJSO();
+    }
+
+    public Point2DArrayJSO noAdjacentPoints() {
+        Point2DArrayJSO no = Point2DArrayJSO.make();
+        int sz = this.length();
+        if (sz < 1) {
+            return no;
+        }
+        Point2D.Point2DJSO p1 = this.get(0);
+        no.push(Point2D.Point2DJSO.make(p1.getX(), p1.getY()));
+        if (sz < 2) {
+            return no;
+        }
+        for (int i = 1; i < sz; i++) {
+            Point2D.Point2DJSO p2 = this.get(i);
+           if (!((p1.getX() == p2.getX()) && (p1.getY() == p2.getY()))) {
+                no.push(Point2D.Point2DJSO.make(p2.getX(), p2.getY()));
+           }
+           p1 = p2;
+        }
+        return no;
+    }
+
+    public Point2DArrayJSO copy() {
+        Point2DArrayJSO no = Point2DArrayJSO.make();
+        int sz = this.length();
+        if (sz < 1) {
+            return no;
+        }
+        for (int i = 0; i < sz; i++) {
+            Point2D.Point2DJSO p = get(i);
+            no.push(Point2D.Point2DJSO.make(p.getX(), p.getY()));
+        }
+        return no;
+    }
+
+}

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresManagerTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresManagerTest.java
@@ -40,7 +40,6 @@ import com.ait.lienzo.client.core.shape.Layer;
 import com.ait.lienzo.client.core.shape.MultiPath;
 import com.ait.lienzo.client.core.shape.Viewport;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeEndEvent;
-import com.ait.lienzo.client.core.shape.wires.handlers.HasDragControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
 import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
 import com.ait.lienzo.client.core.util.ScratchPad;
@@ -154,7 +153,7 @@ public class WiresManagerTest
 
         // Not possible to check used values during drag and drop for now. AlignAndDistributeControls stores calculated primitives (numbers with type double) after registration/re-sizing.
         // But calculations based on AlignAndDistribute#getBoundingBox(group); method  and use plain JSO for calculations, so we will have 0 for any calculations in our's tests.
-        shapeControl.dragStart(mock(HasDragControl.Context.class));
+        shapeControl.dragStart(mock(DragContext.class));
     }
 
     @Test


### PR DESCRIPTION
Hey @SprocketNYC ,

I have seen that you're using the same `lienzo-core` version number for the tests artifact as well, so I have update the pom to use the `lienzo-core` version from the current project version.

I have added some stubs for some array JSOs that Mark is waiting for as well.

Once lienzo core is released (to `2.0.287-RELEASE`), me (or you) can merge this one and, could be possible doing a release for this module too please?

NOTE that this PR does not updates the version of this module, I understand your release process will do it, right??

Thanks in advance!!