### PR TITLE
Upgrade to next lienzo-core 2.0.293 release.

### DIFF
--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresContainerTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresContainerTest.java
@@ -18,23 +18,6 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-
 import com.ait.lienzo.client.core.event.IAttributesChangedBatcher;
 import com.ait.lienzo.client.core.event.NodeDragEndHandler;
 import com.ait.lienzo.client.core.event.NodeDragMoveHandler;
@@ -56,6 +39,22 @@ import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
 import com.google.gwt.event.shared.HandlerManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class WiresContainerTest
@@ -100,8 +99,6 @@ public class WiresContainerTest
     {
         assertNull(tested.getParent());
         assertNull(tested.getDockedTo());
-        assertEquals(IContainmentAcceptor.ALL, tested.getContainmentAcceptor());
-        assertEquals(IDockingAcceptor.ALL, tested.getDockingAcceptor());
         assertEquals(parentContainer, tested.getContainer());
         assertEquals(0, tested.getChildShapes().size());
     }
@@ -131,22 +128,6 @@ public class WiresContainerTest
         final WiresContainer parent = mock(WiresContainer.class);
         tested.setParent(parent);
         assertEquals(parent, tested.getParent());
-    }
-
-    @Test
-    public void testContianmentAcceptor()
-    {
-        final IContainmentAcceptor acceptor = mock(IContainmentAcceptor.class);
-        tested.setContainmentAcceptor(acceptor);
-        assertEquals(acceptor, tested.getContainmentAcceptor());
-    }
-
-    @Test
-    public void testDockingAcceptor()
-    {
-        final IDockingAcceptor acceptor = mock(IDockingAcceptor.class);
-        tested.setDockingAcceptor(acceptor);
-        assertEquals(acceptor, tested.getDockingAcceptor());
     }
 
     @Test

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresManagerTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresManagerTest.java
@@ -18,6 +18,26 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
+import com.ait.lienzo.client.core.Context2D;
+import com.ait.lienzo.client.core.event.NodeDragMoveEvent;
+import com.ait.lienzo.client.core.shape.AbstractDirectionalMultiPointShape;
+import com.ait.lienzo.client.core.shape.Group;
+import com.ait.lienzo.client.core.shape.Layer;
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.client.core.shape.Viewport;
+import com.ait.lienzo.client.core.shape.wires.event.WiresResizeEndEvent;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeHandler;
+import com.ait.lienzo.client.core.util.ScratchPad;
+import com.ait.lienzo.client.widget.DragContext;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
+import com.google.gwt.event.shared.HandlerRegistration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -31,26 +51,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import com.ait.lienzo.client.core.Context2D;
-import com.ait.lienzo.client.core.event.NodeDragMoveEvent;
-import com.ait.lienzo.client.core.shape.AbstractDirectionalMultiPointShape;
-import com.ait.lienzo.client.core.shape.Group;
-import com.ait.lienzo.client.core.shape.Layer;
-import com.ait.lienzo.client.core.shape.MultiPath;
-import com.ait.lienzo.client.core.shape.Viewport;
-import com.ait.lienzo.client.core.shape.wires.event.WiresResizeEndEvent;
-import com.ait.lienzo.client.core.shape.wires.handlers.WiresConnectorControl;
-import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
-import com.ait.lienzo.client.core.util.ScratchPad;
-import com.ait.lienzo.client.widget.DragContext;
-import com.ait.lienzo.test.LienzoMockitoTestRunner;
-import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
-import com.google.gwt.event.shared.HandlerRegistration;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class WiresManagerTest
@@ -107,9 +107,7 @@ public class WiresManagerTest
         final WiresShapeControl shapeControl = spied.register(shape);
         assertNotNull(shapeControl);
         assertNotNull(tested.getShape(shape.uuid()));
-        verify(shape, times(1)).setContainmentAcceptor(eq(containmentAcceptor));
-        verify(shape, times(1)).setDockingAcceptor(eq(dockingAcceptor));
-        verify(shape, times(1)).addWiresShapeHandler(eq(handlerRegistrationManager), any(WiresShape.WiresShapeHandler.class));
+        verify(shape, times(1)).setWiresShapeControl(any(WiresShapeControl.class));
         verify(layer, times(1)).add(eq(shape.getGroup()));
         verify(handlerRegistrationManager, times(4)).register(any(HandlerRegistration.class));
     }
@@ -150,10 +148,6 @@ public class WiresManagerTest
         shape.getHandlerManager().fireEvent(new WiresResizeEndEvent(shape, new NodeDragMoveEvent(mock(DragContext.class)), 1, 1, 11, 11));
         // group.getBoundingBoxAttributes are used for box calculation during shape registration AND trigger re-calculation during shape resize
         verify(group, times(2)).getBoundingBoxAttributes();
-
-        // Not possible to check used values during drag and drop for now. AlignAndDistributeControls stores calculated primitives (numbers with type double) after registration/re-sizing.
-        // But calculations based on AlignAndDistribute#getBoundingBox(group); method  and use plain JSO for calculations, so we will have 0 for any calculations in our's tests.
-        shapeControl.dragStart(mock(DragContext.class));
     }
 
     @Test

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleListTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/WiresShapeControlHandleListTest.java
@@ -18,22 +18,6 @@
 
 package com.ait.lienzo.client.core.shape.wires;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-
 import com.ait.lienzo.client.core.event.NodeDragEndHandler;
 import com.ait.lienzo.client.core.event.NodeDragMoveHandler;
 import com.ait.lienzo.client.core.event.NodeDragStartHandler;
@@ -52,11 +36,29 @@ import com.ait.lienzo.client.core.shape.wires.event.WiresResizeStartEvent;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeStartHandler;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeStepEvent;
 import com.ait.lienzo.client.core.shape.wires.event.WiresResizeStepHandler;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresMagnetsControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.WiresShapeControl;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeHandler;
 import com.ait.lienzo.client.core.types.BoundingBox;
 import com.ait.lienzo.client.core.types.Point2D;
 import com.ait.lienzo.test.LienzoMockitoTestRunner;
 import com.ait.tooling.nativetools.client.collection.NFastArrayList;
 import com.ait.tooling.nativetools.client.event.HandlerRegistrationManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(LienzoMockitoTestRunner.class)
 public class WiresShapeControlHandleListTest
@@ -65,6 +67,15 @@ public class WiresShapeControlHandleListTest
 
     @Mock
     private WiresShape                       shape;
+
+    @Mock
+    private WiresShapeHandler                handler;
+
+    @Mock
+    private WiresShapeControl                control;
+
+    @Mock
+    private WiresMagnetsControl              magnetsControl;
 
     @Mock
     private HandlerRegistrationManager       handlerRegistrationManager;
@@ -100,6 +111,9 @@ public class WiresShapeControlHandleListTest
         final Layer layer = new Layer();
         final Group group = new Group();
         layer.add(group);
+        doReturn(magnetsControl).when(control).getMagnetsControl();
+        doReturn(control).when(handler).getControl();
+        doReturn(control).when(shape).getControl();
         doReturn(group).when(shape).getGroup();
         doReturn(children).when(shape).getChildShapes();
         doReturn(false).when(controlHandleList).isEmpty();
@@ -153,6 +167,9 @@ public class WiresShapeControlHandleListTest
     {
         final WiresShape realShape = new WiresShape(new MultiPath().rect(0, 0, 10, 10));
         tested = new WiresShapeControlHandleList(realShape, IControlHandle.ControlHandleStandardType.RESIZE, controlHandleList, handlerRegistrationManager);
+        WiresManager.setWiresShapeHandler(realShape,
+                                          handlerRegistrationManager,
+                                          handler);
 
         setCPLocations(1, 2, 11, 12, 3, 13, 14, 4);
 
@@ -347,6 +364,7 @@ public class WiresShapeControlHandleListTest
 
         tested = spy(tested);
         tested.refresh();
+        verify(magnetsControl).shapeChanged();
         verify(tested).resize(null, null, 10.0, 12.0, true);
     }
 

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresParentPickerControlImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresParentPickerControlImplTest.java
@@ -1,0 +1,83 @@
+package com.ait.lienzo.client.core.shape.wires.handlers.impl;
+
+import com.ait.lienzo.client.core.shape.Layer;
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.client.core.shape.wires.PickerPart;
+import com.ait.lienzo.client.core.shape.wires.WiresLayer;
+import com.ait.lienzo.client.core.shape.wires.WiresManager;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.shape.wires.picker.ColorMapBackedPicker;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class WiresParentPickerControlImplTest {
+
+    private static final double START_X = 3;
+    private static final double START_Y = 5;
+
+    @Mock
+    private ColorMapBackedPicker picker;
+
+    private ColorMapBackedPicker.PickerOptions pickerOptions = new ColorMapBackedPicker.PickerOptions(false, 0);
+    private WiresParentPickerControlImpl tested;
+    private Layer layer;
+    private WiresManager manager;
+    private WiresShape shape;
+    private WiresShape parent;
+
+    @Before
+    public void setup()
+    {
+        layer = new Layer();
+        manager = WiresManager.get(layer);
+        shape = new WiresShape(new MultiPath().rect(0, 0, 10, 10));
+        shape.setWiresManager(manager);
+        parent = new WiresShape(new MultiPath().rect(0, 0, 100, 100));
+        parent.setWiresManager(manager);
+        tested = new WiresParentPickerControlImpl(new WiresShapeLocationControlImpl(shape),
+                                                  new WiresParentPickerControlImpl.ColorMapBackedPickerProvider() {
+                                                      @Override
+                                                      public ColorMapBackedPicker get(WiresLayer layer) {
+                                                          return picker;
+                                                      }
+
+                                                      @Override
+                                                      public ColorMapBackedPicker.PickerOptions getOptions() {
+                                                          return pickerOptions;
+                                                      }
+                                                  });
+    }
+
+    @Test
+    public void testReturnParentAtCertainLocation()
+    {
+        // Start moving shape.
+        tested.onMoveStart(START_X,
+                           START_Y);
+        assertEquals(manager.getLayer(), tested.getParent());
+        // Mock find method to return parent at the following location.
+        when(picker.findShapeAt(eq((int) (START_X + 10)),
+                                eq((int) (START_Y + 10))))
+                .thenReturn(new PickerPart(parent, PickerPart.ShapePart.BODY));
+
+        // Move step. Parent is here.
+        double dx = 10d;
+        double dy = 10d;
+        tested.onMove(dx, dy);
+        assertEquals(parent, tested.getParent());
+
+        // Move step. Parent no here.
+        dx = -10d;
+        dy = -10d;
+        tested.onMove(dx, dy);
+        assertEquals(manager.getLayer(), tested.getParent());
+    }
+}

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeLocationControlImplTest.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/handlers/impl/WiresShapeLocationControlImplTest.java
@@ -1,0 +1,109 @@
+package com.ait.lienzo.client.core.shape.wires.handlers.impl;
+
+import com.ait.lienzo.client.core.shape.MultiPath;
+import com.ait.lienzo.client.core.shape.wires.WiresShape;
+import com.ait.lienzo.client.core.types.Point2D;
+import com.ait.lienzo.test.LienzoMockitoTestRunner;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(LienzoMockitoTestRunner.class)
+public class WiresShapeLocationControlImplTest {
+
+    private static final double START_X = 3;
+    private static final double START_Y = 5;
+
+    private WiresShapeLocationControlImpl tested;
+    private WiresShape shape;
+
+    @Before
+    public void setup() {
+        shape = new WiresShape(new MultiPath().rect(0, 0, 10, 10));
+        this.tested = new WiresShapeLocationControlImpl(shape);
+        assertEquals(shape, tested.getShape());
+    }
+
+    @Test
+    public void testOnMoveStart() {
+        tested.onMoveStart(START_X, START_Y);
+        assertEquals(START_X, tested.getMouseStartX(), 0);
+        assertEquals(START_Y, tested.getMouseStartY(), 0);
+        assertEquals(5, tested.getShapeStartCenterX(), 0);
+        assertEquals(5, tested.getShapeStartCenterY(), 0);
+        assertEquals(new Point2D(0, 0), tested.getShapeInitialLocation());
+        assertEquals(new Point2D(0, 0), tested.getAdjust());
+        assertEquals(new Point2D(START_X, START_Y), tested.getCurrentLocation());
+        assertEquals(new Point2D(0, 0), tested.getCurrentDelta());
+        assertFalse(tested.isStartDocked());
+    }
+
+    @Test
+    public void testOnMove() {
+        final double x = 1.5;
+        final double y = 2.2;
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(x, y);
+        assertEquals(new Point2D(0, 0), tested.getAdjust());
+        assertEquals(new Point2D(START_X + x, START_Y + y), tested.getCurrentLocation());
+        assertEquals(new Point2D(x, y), tested.getCurrentDelta());
+    }
+
+    @Test
+    public void testOnMoveComplete() {
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(1, 2);
+        assertTrue(tested.onMoveComplete());
+    }
+
+    @Test
+    public void testOnMoveAdjusted() {
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(1, 2);
+        assertEquals(new Point2D(1, 2), tested.getCurrentDelta());
+        assertEquals(new Point2D(START_X + 1, START_Y + 2), tested.getCurrentLocation());
+        tested.onMoveAdjusted(new Point2D(6, 22));
+        assertEquals(new Point2D(6, 22), tested.getCurrentDelta());
+        assertEquals(new Point2D(START_X + 6, START_Y + 22), tested.getCurrentLocation());
+    }
+
+    @Test
+    public void testClear() {
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(1, 2);
+        tested.clear();
+        assertEquals(0, tested.getMouseStartX(), 0);
+        assertEquals(0, tested.getMouseStartY(), 0);
+        assertEquals(0, tested.getShapeStartCenterX(), 0);
+        assertEquals(0, tested.getShapeStartCenterY(), 0);
+        assertEquals(new Point2D(0, 0), tested.getAdjust());
+        assertEquals(new Point2D(0, 0), tested.getCurrentDelta());
+        assertEquals(new Point2D(0, 0), tested.getCurrentLocation());
+        assertNull(tested.getShapeInitialLocation());
+    }
+
+    @Test
+    public void testExecute() {
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(1, 2);
+        tested.onMoveComplete();
+        tested.execute();
+        assertEquals(new Point2D(START_X + 1, START_Y + 2), tested.getCurrentLocation());
+        assertEquals(new Point2D(START_X + 1, START_Y + 2), shape.getLocation());
+    }
+
+    @Test
+    public void testReset() {
+        tested.onMoveStart(START_X, START_Y);
+        tested.onMove(1, 2);
+        tested.onMoveComplete();
+        assertEquals(new Point2D(START_X + 1, START_Y + 2), tested.getCurrentLocation());
+        tested.reset();
+        assertEquals(new Point2D(0, 0), shape.getLocation());
+    }
+}

--- a/src/test/java/com/ait/lienzo/client/core/shape/wires/suite/WiresTestSuite.java
+++ b/src/test/java/com/ait/lienzo/client/core/shape/wires/suite/WiresTestSuite.java
@@ -22,6 +22,8 @@ import com.ait.lienzo.client.core.shape.wires.WiresContainerTest;
 import com.ait.lienzo.client.core.shape.wires.WiresManagerTest;
 import com.ait.lienzo.client.core.shape.wires.WiresShapeControlHandleListTest;
 import com.ait.lienzo.client.core.shape.wires.WiresShapeTest;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresParentPickerControlImplTest;
+import com.ait.lienzo.client.core.shape.wires.handlers.impl.WiresShapeLocationControlImplTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -36,6 +38,8 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({WiresContainerTest.class,
         WiresShapeTest.class,
         WiresShapeControlHandleListTest.class,
+        WiresShapeLocationControlImplTest.class,
+        WiresParentPickerControlImplTest.class,
         WiresManagerTest.class,
         TextBoundsWrapTest.class,
         TextLineBreakWrapTest.class})


### PR DESCRIPTION
- Upgrade to next lienzo-core 2.0.293 release.
- Added tests for shape location and parent picker controls.

**Depends on** https://github.com/ahome-it/lienzo-core/pull/200